### PR TITLE
Отключаем отправку событий в Sentry, если сервис открыт на стороннем домене

### DIFF
--- a/src/preset/browser/index.ts
+++ b/src/preset/browser/index.ts
@@ -17,7 +17,7 @@ import { create } from 'middleware-axios';
 import type { BaseConfig } from '../../config/types';
 import { BridgeClientSide, SsrBridge } from '../../utils/ssr';
 import { StrictMap, KnownHttpApiKey } from '../types';
-import { HttpApiHostPool } from '../utils';
+import { eqHostname, HttpApiHostPool } from '../utils';
 import { loggingMiddleware } from '../../http-client/middleware/logging';
 import { HttpClientFactory } from '../../http-client/types';
 
@@ -42,6 +42,9 @@ export function provideBaseConfig(resolve: Resolve): BaseConfig {
 export function provideLogger(resolve: Resolve): Logger {
   const source = resolve(KnownToken.Config.source);
 
+  /* Регулярное выражение поддоменов sima-land */
+  const SIMA_LAND_ORIGIN_HOSTS = /(.+?\.|^)sima-land\.\w+$/;
+
   const client = new BrowserClient({
     transport: makeFetchTransport,
     stackParser: defaultStackParser,
@@ -49,6 +52,7 @@ export function provideLogger(resolve: Resolve): Logger {
     release: source.require('SENTRY_RELEASE'),
     environment: source.require('PUBLIC_SENTRY_ENVIRONMENT'),
     integrations: [...defaultIntegrations],
+    enabled: eqHostname(SIMA_LAND_ORIGIN_HOSTS),
   });
 
   const hub = new Hub(client);

--- a/src/preset/browser/index.ts
+++ b/src/preset/browser/index.ts
@@ -17,7 +17,7 @@ import { create } from 'middleware-axios';
 import type { BaseConfig } from '../../config/types';
 import { BridgeClientSide, SsrBridge } from '../../utils/ssr';
 import { StrictMap, KnownHttpApiKey } from '../types';
-import { eqHostname, HttpApiHostPool } from '../utils';
+import { HttpApiHostPool } from '../utils';
 import { loggingMiddleware } from '../../http-client/middleware/logging';
 import { HttpClientFactory } from '../../http-client/types';
 
@@ -52,7 +52,7 @@ export function provideLogger(resolve: Resolve): Logger {
     release: source.require('SENTRY_RELEASE'),
     environment: source.require('PUBLIC_SENTRY_ENVIRONMENT'),
     integrations: [...defaultIntegrations],
-    enabled: eqHostname(SIMA_LAND_ORIGIN_HOSTS),
+    enabled: SIMA_LAND_ORIGIN_HOSTS.test(window.location.hostname),
   });
 
   const hub = new Hub(client);

--- a/src/preset/utils.ts
+++ b/src/preset/utils.ts
@@ -28,12 +28,3 @@ export class HttpApiHostPool<Key extends string> implements StrictMap<Key> {
     return this.source.require(variableName);
   }
 }
-
-/**
- * Проверяет соответствие имени хоста паттерну.
- * @param pattern Паттерн.
- * @return Признак соответствия.
- */
-export function eqHostname(pattern: RegExp) {
-  return typeof window !== 'undefined' && pattern.test(window.location.hostname);
-}

--- a/src/preset/utils.ts
+++ b/src/preset/utils.ts
@@ -28,3 +28,12 @@ export class HttpApiHostPool<Key extends string> implements StrictMap<Key> {
     return this.source.require(variableName);
   }
 }
+
+/**
+ * Проверяет соответствие имени хоста паттерну.
+ * @param pattern Паттерн.
+ * @return Признак соответствия.
+ */
+export function eqHostname(pattern: RegExp) {
+  return typeof window !== 'undefined' && pattern.test(window.location.hostname);
+}


### PR DESCRIPTION
Проблема:  
Сайт может быть открыт на стороннем домене, например, сохраненная страница в Yandex - `yandexwebache.net`  
В этом случае блокируется вся функциональность, зависящая от CORS - xhr запросы, работа с history и т.д. Страница становится условно нерабочей.   
Но, так как sentry доступен в таком окружении, то все эти ошибки отправляются в sentry, и искажают нормальный фон ошибок (примерно 10-15 событий с одного открытия страницы).  
  
Предложение:  
Отключаем отправку событий в sentry, если текущий хост не соответствует поддоменам sima-land.  
Не делаем саму инициализацию условной, чтобы сохранить логгер неизменным, но при этом заглушить события.