### PR TITLE
#31 collectCookieMiddleware пытается установить заголовок на отправленный ответ 

### DIFF
--- a/src/http-client/middleware/cookie.ts
+++ b/src/http-client/middleware/cookie.ts
@@ -24,7 +24,7 @@ export function collectCookieMiddleware(request: Request, response: Response): M
       },
     });
 
-    if (result.headers['set-cookie']) {
+    if (result.headers['set-cookie'] && !response.writableEnded) {
       store.set(result.headers['set-cookie']);
       response.setHeader('cookie', store.asHeader());
     }

--- a/src/http-client/middleware/headers.ts
+++ b/src/http-client/middleware/headers.ts
@@ -28,6 +28,7 @@ export function passHeadersMiddleware(
       }
     }
 
-    await next({ ...config, headers });
+    // ВАЖНО: не ждем ответа тк он может упасть + нам не важен результат
+    next({ ...config, headers });
   };
 }

--- a/src/utils/redux-saga/types.ts
+++ b/src/utils/redux-saga/types.ts
@@ -1,17 +1,41 @@
 import type { Middleware } from '@reduxjs/toolkit';
 import type { Saga, SagaMiddlewareOptions } from 'redux-saga';
 
+/** Опции остановки redux-saga. */
+export interface SagaInterruptConfig {
+  strategy?: 'dispatch-end' | 'cancel-task';
+}
+
+/** Информация, которая приходит вторым аргументом в обработчик ошибки SagaMiddleware. */
 export type SagaErrorInfo = Parameters<Required<SagaMiddlewareOptions>['onError']>[1];
 
+/** Информация об остановке redux-saga. */
 export interface SagaInterruptInfo {
   timeout: number;
 }
 
+/** Опции запуска redux-saga с остановкой по таймауту. */
+export interface SagaTimeoutRunData<S extends Saga> {
+  saga: S;
+  args: Parameters<S>;
+  timeout: number;
+}
+
+/** Кастомная версия SagaMiddleware. */
 export interface SagaExtendedMiddleware extends Middleware {
-  timeout(milliseconds: number): this;
+  /**
+   * Установить временное ограничение работы саги.
+   * Если сага не успела выполнится до истечения этого ограничения она будет принудительно завершена.
+   */
+  timeout(milliseconds: number, config?: SagaInterruptConfig): this;
+
+  /**
+   * Запускает сагу.
+   */
   run: <S extends Saga>(saga: S, ...args: Parameters<S>) => Promise<void>;
 }
 
+/** Обработчик событий SagaExtendedMiddleware. */
 export interface SagaMiddlewareHandler {
   onSagaError(error: Error, errorInfo: SagaErrorInfo): Promise<void> | void;
   onConfigError(error: Error): Promise<void> | void;


### PR DESCRIPTION
- utils: `createSagaExtendedMiddleware` теперь позволяет задать стратегию остановки saga
- http-client: `collectCookieMiddleware` теперь устанавливает заголовок на ответ только если он не завершен
- http-client: `passHeadersMiddleware` теперь не дожидается завершения запроса и как следствие не падает вместе с ним