### PR TITLE
#36 Доработать утилиты для http-клиентов

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,9 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           registry-url: https://registry.npmjs.org/
 
       - uses: ./.github/actions/publish-notify
@@ -21,9 +22,7 @@ jobs:
           tg-chat-id: ${{ secrets.TG_CHAT_ID }}
 
       - name: Install dependencies
-        run: |
-          npm i -g npm@7 --registry=https://registry.npmjs.org
-          npm ci
+        run: npm ci
 
       - name: Lint
         run: |
@@ -36,13 +35,13 @@ jobs:
       - name: Build package
         run: |
           npm --no-git-tag-version version ${GITHUB_REF#refs/*/}
-          npm set-script prepare ""
+          npm pkg delete scripts.prepare
           npm run build
 
       - name: Publish build
         run: npm publish ./dist --access public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
 
       - uses: ./.github/actions/publish-notify
         if: success()

--- a/src/http-client/sauce/index.ts
+++ b/src/http-client/sauce/index.ts
@@ -58,7 +58,7 @@ export function sauce(instance: AxiosInstance | AxiosInstanceWrapper): Sauce {
  * @param info Результат вызова метода экземпляра axios.
  * @return Отформатированный ответ.
  */
-export function formatResultInfo(info: SafetyInfo<AxiosResponse>): SauceResponse {
+export function formatResultInfo<T>(info: SafetyInfo<AxiosResponse<T>>): SauceResponse<T> {
   if (info.ok) {
     return {
       ok: true,

--- a/src/http-client/types.ts
+++ b/src/http-client/types.ts
@@ -4,5 +4,5 @@ import type { AxiosInstanceWrapper } from 'middleware-axios';
 export type HttpClient = AxiosInstanceWrapper;
 
 export interface HttpClientFactory {
-  (config: AxiosRequestConfig): HttpClient;
+  (config?: AxiosRequestConfig): HttpClient;
 }

--- a/src/preset/browser/index.ts
+++ b/src/preset/browser/index.ts
@@ -82,7 +82,7 @@ export function provideKnownHttpApiHosts(resolve: Resolve): StrictMap<KnownHttpA
 export function provideHttpClientFactory(resolve: Resolve): HttpClientFactory {
   const logHandler = resolve(KnownToken.Http.Client.LogMiddleware.handler);
 
-  return function createHttpClient(config) {
+  return function createHttpClient(config = {}) {
     const client = create(config);
 
     client.use(HttpStatus.createMiddleware());

--- a/src/preset/node/response.ts
+++ b/src/preset/node/response.ts
@@ -49,7 +49,7 @@ export function provideHttpClientFactory(resolve: Resolve): HttpClientFactory {
   //   controller.abort();
   // });
 
-  return function createHttpClient(config) {
+  return function createHttpClient(config = {}) {
     const client = create({
       ...config,
       headers: {

--- a/src/utils/react/error-handlers/index.tsx
+++ b/src/utils/react/error-handlers/index.tsx
@@ -1,17 +1,17 @@
-import { Component, Suspense } from 'react';
+import { Component, ErrorInfo, ReactNode, Suspense } from 'react';
 
 /**
  * Опции компонентов ErrorBoundary и SafeSuspense.
  */
 export interface Props {
   /** Дочерний элемент. */
-  children: NonNullable<React.ReactNode> | null;
+  children: NonNullable<ReactNode> | null;
 
   /** Содержимое, которое будет выведено если возникла ошибка. */
-  fallback: NonNullable<React.ReactNode> | null;
+  fallback: NonNullable<ReactNode> | null;
 
   /** Функция для логирования ошибок. */
-  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
 }
 
 /**
@@ -57,10 +57,12 @@ export class ErrorBoundary extends Component<Props, { hasError: boolean }> {
  * @param props Свойства.
  * @return Элемент.
  */
-export const SafeSuspense = ({ children, fallback, onError }: Props) => (
-  <Suspense fallback={fallback}>
-    <ErrorBoundary fallback={fallback} onError={onError}>
-      {children}
-    </ErrorBoundary>
-  </Suspense>
-);
+export function SafeSuspense({ children, fallback, onError }: Props) {
+  return (
+    <Suspense fallback={fallback}>
+      <ErrorBoundary fallback={fallback} onError={onError}>
+        {children}
+      </ErrorBoundary>
+    </Suspense>
+  );
+}


### PR DESCRIPTION
- мелкие правки CI (patch)
- теперь конфиг HttpClientFactory необязателен (minor)
- правки пресетов после обновления HttpClientFactory (minor)
- стилистические правки `utils/react` (patch)
- `http-client/sauce`: теперь `formatResultInfo` имеет жинерик для вывода типа результата (minor)

Closes #36