### PR TITLE
#52  SSR: При обрывании саги слать ошибку с уровнем warning #52 

### DIFF
--- a/src/preset/browser/index.ts
+++ b/src/preset/browser/index.ts
@@ -89,7 +89,7 @@ export function provideHttpClientFactory(resolve: Resolve): HttpClientFactory {
   return function createHttpClient(config = {}) {
     const client = create(config);
 
-    client.use(HttpStatus.createMiddleware());
+    client.use(HttpStatus.axiosMiddleware());
     client.use(logMiddleware(logHandler));
 
     return client;

--- a/src/preset/node/handler.ts
+++ b/src/preset/node/handler.ts
@@ -65,7 +65,7 @@ export function provideHttpClientFactory(resolve: Resolve): HttpClientFactory {
       },
     });
 
-    client.use(HttpStatus.createMiddleware());
+    client.use(HttpStatus.axiosMiddleware());
     client.use(tracingMiddleware(tracer, context.res.locals.tracing.rootContext));
     client.use(logMiddleware(logHandler));
     client.use(

--- a/src/preset/parts/__test__/utils.test.ts
+++ b/src/preset/parts/__test__/utils.test.ts
@@ -400,7 +400,7 @@ describe('HttpStatus', () => {
   });
 
   describe('createMiddleware', () => {
-    const middleware = HttpStatus.createMiddleware();
+    const middleware = HttpStatus.axiosMiddleware();
 
     it('should NOT change validateStatus when is already defined as null', async () => {
       const config = { validateStatus: null };

--- a/src/preset/parts/utils.ts
+++ b/src/preset/parts/utils.ts
@@ -248,7 +248,11 @@ export class SagaLogging implements SagaMiddlewareHandler {
    * @param info Инфо прерывания саги.
    */
   onTimeoutInterrupt({ timeout }: SagaInterruptInfo) {
-    this.logger.error(new Error(`Сага прервана по таймауту (${timeout} миллисекунд)`));
+    this.logger.error(
+      new DetailedError(`Сага прервана по таймауту (${timeout}мс)`, {
+        level: 'warning',
+      }),
+    );
   }
 }
 
@@ -286,7 +290,7 @@ export abstract class HttpStatus {
    * Валидация применяется только если в конфиге запроса не указан validateStatus.
    * @return Промежуточный слой.
    */
-  static createMiddleware(): Middleware<unknown> {
+  static axiosMiddleware(): Middleware<unknown> {
     return async (config, next, defaults) => {
       if (config.validateStatus !== undefined || defaults.validateStatus !== undefined) {
         // если validateStatus указан явно то не применяем валидацию по умолчанию


### PR DESCRIPTION
- preset/parts: теперь SagaLogging шлет ошибку с уровнем warning при обрывании саги (patch)
- preset/parts: HttpStatus.createMiddleware переименован в HttpStatus.axiosMiddleware (major)

Closes #52