### PR TITLE
Шаг 51 #38

### DIFF
--- a/src/preset/bun/bun/providers/index.ts
+++ b/src/preset/bun/bun/providers/index.ts
@@ -3,13 +3,14 @@ import { Resolve } from '../../../../di';
 import { KnownToken } from '../../../../tokens';
 import { ConfigSource, createConfigSource } from '../../../../config';
 import { Logger, createLogger } from '../../../../log';
-import { Handler, Middleware, applyMiddleware, configureFetch, log } from '../../../../http';
+import { Handler, Middleware, applyMiddleware, log } from '../../../../http';
 import { ServeLogging } from '../utils';
 import { providePinoHandler } from '../../../node/node/providers';
 import { route, router } from '@krutoo/fetch-tools';
 import { getCurrentHub, init, runWithAsyncContext } from '@sentry/bun';
 import { createSentryHandler } from '../../../../log/handler/sentry';
 import { healthCheck } from '../../../isomorphic/utils';
+import { provideFetch } from '../../../isomorphic/providers';
 
 export const BunProviders = {
   configSource(): ConfigSource {
@@ -43,11 +44,7 @@ export const BunProviders = {
     return createSentryHandler(getCurrentHub);
   },
 
-  fetch(resolve: Resolve): typeof fetch {
-    const middleware = resolve(KnownToken.Http.Fetch.middleware);
-
-    return configureFetch(fetch, applyMiddleware(...middleware));
-  },
+  fetch: provideFetch,
 
   fetchMiddleware(): Middleware[] {
     return [];

--- a/src/preset/bun/bun/utils/index.ts
+++ b/src/preset/bun/bun/utils/index.ts
@@ -2,15 +2,11 @@
 import { DoneLogData, FailLogData, FetchUtil, LogData, LogHandler } from '../../../../http';
 import { DetailedError, Logger } from '../../../../log';
 import { toMilliseconds } from '../../../../utils';
-
-export function getClientIp(request: Request): string | null {
-  const headerValue = request.headers.get('x-client-ip') || request.headers.get('x-forwarded-for');
-
-  return headerValue;
-}
+import { getClientIp } from '../../../server/utils';
 
 /**
  * Логирование обработки входящих http-запросов.
+ * @todo Перенести в preset/server?
  */
 export class ServeLogging implements LogHandler {
   logger: Logger;

--- a/src/preset/bun/handler/index.ts
+++ b/src/preset/bun/handler/index.ts
@@ -2,7 +2,11 @@
 import { createPreset } from '../../../di';
 import { KnownToken } from '../../../tokens';
 import { PresetTuner } from '../../isomorphic';
-import { provideReduxMiddlewareSaga } from '../../isomorphic/providers';
+import {
+  provideAbortController,
+  provideFetch,
+  provideReduxMiddlewareSaga,
+} from '../../isomorphic/providers';
 import { providePageRender } from '../../node/handler/providers';
 import { SpecificExtras } from '../../node/handler/utils';
 import { HandlerProviders } from './providers';
@@ -11,8 +15,9 @@ export function PresetHandler(customize?: PresetTuner) {
   const preset = createPreset();
 
   // http fetch
-  preset.set(KnownToken.Http.fetch, HandlerProviders.fetch);
-  preset.set(KnownToken.Http.Fetch.abortController, HandlerProviders.fetchAbortController);
+  preset.set(KnownToken.Http.fetch, provideFetch);
+  preset.set(KnownToken.Http.Fetch.abortController, provideAbortController);
+  preset.set(KnownToken.Http.Fetch.cookieStore, HandlerProviders.cookieStore);
   preset.set(KnownToken.Http.Fetch.middleware, HandlerProviders.fetchMiddleware);
 
   // handler

--- a/src/preset/bun/handler/providers/index.tsx
+++ b/src/preset/bun/handler/providers/index.tsx
@@ -7,7 +7,6 @@ import {
   Middleware,
   ResponseError,
   applyMiddleware,
-  configureFetch,
   cookie,
   createCookieStore,
   defaultHeaders,
@@ -15,6 +14,7 @@ import {
 } from '../../../../http';
 import { Fragment } from 'react';
 import { FetchLogging } from '../../../isomorphic/utils';
+import { provideAbortController, provideFetch } from '../../../isomorphic/providers';
 import { getForwardedHeaders, getResponseFormat } from '../utils';
 
 export const HandlerProviders = {
@@ -156,15 +156,9 @@ export const HandlerProviders = {
     }
   },
 
-  fetch(resolve: Resolve): typeof fetch {
-    const middleware = resolve(KnownToken.Http.Fetch.middleware);
+  fetch: provideFetch,
 
-    return configureFetch(fetch, applyMiddleware(...middleware));
-  },
-
-  fetchAbortController(): AbortController {
-    return new AbortController();
-  },
+  fetchAbortController: provideAbortController,
 
   fetchMiddleware(resolve: Resolve): Middleware[] {
     const config = resolve(KnownToken.Config.base);
@@ -188,7 +182,7 @@ export const HandlerProviders = {
     return [
       // ВАЖНО: слой логирования ошибки ПЕРЕД остальными слоями чтобы не упустить ошибки выше
       log({
-        onCatch: data => logging.onRequest(data),
+        onCatch: data => logging.onCatch(data),
       }),
 
       (request, next) => next(new Request(request, { signal: abortController.signal })),

--- a/src/preset/bun/handler/utils/index.ts
+++ b/src/preset/bun/handler/utils/index.ts
@@ -1,9 +1,7 @@
 /* eslint-disable require-jsdoc, jsdoc/require-jsdoc */
 import type { Handler } from '../../../../http';
-import type { BaseConfig } from '../../../../config';
 import { KnownToken } from '../../../../tokens';
 import { CURRENT_APP, type Application, type Resolve } from '../../../../di';
-import { getClientIp } from '../../bun/utils';
 
 export function HandlerProvider(getApp: () => Application) {
   return (resolve: Resolve): Handler => {
@@ -18,40 +16,4 @@ export function HandlerProvider(getApp: () => Application) {
       return app.get(KnownToken.Http.Handler.main)(request);
     };
   };
-}
-
-export function getResponseFormat(request: Request): 'html' | 'json' {
-  let result: 'html' | 'json' = 'html';
-
-  if ((request.headers.get('accept') || '').toLowerCase().includes('application/json')) {
-    result = 'json';
-  }
-
-  return result;
-}
-
-export function getForwardedHeaders(config: BaseConfig, request: Request): Headers {
-  const result = new Headers();
-
-  // user agent
-  result.set('User-Agent', `simaland-${config.appName}/${config.appVersion}`);
-
-  // client ip
-  const clientIp = getClientIp(request);
-
-  if (clientIp) {
-    result.set('X-Client-Ip', clientIp);
-  }
-
-  // service headers
-  request.headers.forEach((headerValue, headerName) => {
-    if (
-      headerName.toLowerCase().startsWith('simaland-') &&
-      headerName.toLowerCase() !== 'simaland-params'
-    ) {
-      result.set(headerName, headerValue);
-    }
-  });
-
-  return result;
 }

--- a/src/preset/isomorphic/types.ts
+++ b/src/preset/isomorphic/types.ts
@@ -4,7 +4,7 @@ export interface PresetTuner {
   (tools: { override: <T>(token: Token<T>, provider: Provider<T>) => void }): void;
 }
 
-export type KnownHttpApiKey = 'ilium' | 'simaV3' | 'simaV4' | 'simaV6';
+export type KnownHttpApiKey = 'ilium' | 'simaV3' | 'simaV4' | 'simaV6' | 'chponkiV2';
 
 /**
  * Строгая версия Map без возможности добавлять/удалять.

--- a/src/preset/isomorphic/utils/__test__/index.test.ts
+++ b/src/preset/isomorphic/utils/__test__/index.test.ts
@@ -116,6 +116,21 @@ describe('HttpApiHostPool', () => {
       pool.get('bar' as any);
     }).toThrow(`Known HTTP API not found by key "bar"`);
   });
+
+  it('should handle absolute option', () => {
+    const source = new Env({
+      API_HOST_FOOBAR: 'http://www.foobar.com',
+    });
+
+    const pool = new HttpApiHostPool(
+      {
+        foobar: 'API_HOST_FOOBAR',
+      },
+      source,
+    );
+
+    expect(pool.get('foobar', { absolute: true })).toEqual('http://www.foobar.com');
+  });
 });
 
 describe('severityFromStatus', () => {

--- a/src/preset/isomorphic/utils/index.ts
+++ b/src/preset/isomorphic/utils/index.ts
@@ -34,7 +34,7 @@ export class HttpApiHostPool<Key extends string> implements StrictMap<Key> {
   }
 
   /** @inheritDoc */
-  get(key: Key): string {
+  get(key: Key, { absolute }: { absolute?: boolean } = {}): string {
     const variableName = this.map[key];
 
     if (!variableName) {
@@ -42,7 +42,13 @@ export class HttpApiHostPool<Key extends string> implements StrictMap<Key> {
     }
 
     // "лениво" берём переменную, именно в момент вызова (чтобы не заставлять указывать в сервисах все переменные разом)
-    return this.source.require(variableName);
+    const value = this.source.require(variableName);
+
+    if (absolute) {
+      return new Request(value).url;
+    }
+
+    return value;
   }
 }
 

--- a/src/preset/node/handler/index.ts
+++ b/src/preset/node/handler/index.ts
@@ -1,6 +1,11 @@
 import { Preset, createPreset } from '../../../di';
 import { KnownToken } from '../../../tokens';
-import { provideReduxMiddlewareSaga, provideAxiosLogHandler } from '../../isomorphic/providers';
+import {
+  provideReduxMiddlewareSaga,
+  provideAxiosLogHandler,
+  provideFetch,
+  provideAbortController,
+} from '../../isomorphic/providers';
 import { PresetTuner } from '../../isomorphic/types';
 import {
   provideAxiosFactory,
@@ -8,6 +13,8 @@ import {
   provideSpecificParams,
   providePageHelmet,
   providePageRender,
+  provideFetchMiddleware,
+  provideCookieStore,
 } from './providers';
 import { SpecificExtras } from './utils';
 
@@ -20,6 +27,12 @@ import { SpecificExtras } from './utils';
 export function PresetHandler(customize?: PresetTuner): Preset {
   // ВАЖНО: используем .set() вместо аргумента defaults функции createPreset из-за скорости
   const preset = createPreset();
+
+  // fetch
+  preset.set(KnownToken.Http.fetch, provideFetch);
+  preset.set(KnownToken.Http.Fetch.middleware, provideFetchMiddleware);
+  preset.set(KnownToken.Http.Fetch.cookieStore, provideCookieStore);
+  preset.set(KnownToken.Http.Fetch.abortController, provideAbortController);
 
   // saga
   preset.set(KnownToken.Redux.Middleware.saga, provideReduxMiddlewareSaga);

--- a/src/preset/node/handler/providers/index.tsx
+++ b/src/preset/node/handler/providers/index.tsx
@@ -1,68 +1,27 @@
-import { ResponseError, createCookieStore } from '../../../../http';
+import {
+  Middleware,
+  ResponseError,
+  cookie,
+  createCookieStore,
+  defaultHeaders,
+  log,
+} from '../../../../http';
 import { Resolve } from '../../../../di';
 import { KnownToken } from '../../../../tokens';
-import { getForwardedHeaders, tracingMiddleware } from '../../node/utils/http-client';
+import {
+  getForwardedHeaders as getForwardedHeadersExpress,
+  tracingMiddleware as tracingMiddlewareAxios,
+} from '../../node/utils/http-client';
 import { CreateAxiosDefaults } from 'axios';
 import { create } from 'middleware-axios';
-import { HttpStatus } from '../../../isomorphic/utils';
+import { FetchLogging, HttpStatus } from '../../../isomorphic/utils';
 import { cookieMiddleware, logMiddleware } from '../../../../utils/axios';
 import { RESPONSE_EVENT_TYPE } from '../../../isomorphic/constants';
 import { ConventionalJson } from '../../../isomorphic/types';
 import { Fragment } from 'react';
-import { HelmetContext, RegularHelmet, getResponseFormat } from '../utils';
+import { HelmetContext, RegularHelmet, getPageResponseFormat } from '../utils';
 import { renderToString } from 'react-dom/server';
-
-/**
- * Провайдер фабрики http-клиентов.
- * @param resolve Функция для получения зависимости по токену.
- * @return Фабрика.
- */
-export function provideAxiosFactory(resolve: Resolve) {
-  // @todo а что если привести все зависимости к виду:
-  // const getAppConfig = resolve.lazy(KnownToken.Config.base);
-
-  const appConfig = resolve(KnownToken.Config.base);
-  const tracer = resolve(KnownToken.Tracing.tracer);
-  const context = resolve(KnownToken.ExpressHandler.context);
-  const logHandler = resolve(KnownToken.Axios.Middleware.Log.handler);
-
-  // @todo добавить при необходимости (но тогда в логе будет значительно больше ошибок)
-  // можно не отсылать ошибки из клиента если ответ от сервера уже ушел (writableEnded)
-  // const controller = new AbortController();
-  // context.res.on('finish', () => {
-  //   controller.abort();
-  // });
-
-  // ВАЖНО: для всех клиентов в рамках обработчика должно быть одно хранилище cookie
-  const cookieStore = createCookieStore(context.req.header('cookie'));
-
-  cookieStore.subscribe(() => {
-    if (!context.res.writableEnded) {
-      context.res.setHeader('cookie', cookieStore.getCookies());
-    }
-  });
-
-  const defaultHeaders = getForwardedHeaders(appConfig, context.req);
-
-  return (config: CreateAxiosDefaults = {}) => {
-    const client = create({
-      ...config,
-      headers: {
-        ...defaultHeaders,
-
-        // @todo убрать as any
-        ...(config.headers as any),
-      },
-    });
-
-    client.use(HttpStatus.axiosMiddleware());
-    client.use(tracingMiddleware(tracer, context.res.locals.tracing.rootContext));
-    client.use(logMiddleware(logHandler));
-    client.use(cookieMiddleware(cookieStore));
-
-    return client;
-  };
-}
+import { tracingMiddleware } from '../../../server/utils';
 
 /**
  * Провайдер главной функции обработчика входящего http-запроса.
@@ -77,6 +36,7 @@ export function provideHandlerMain(resolve: Resolve): VoidFunction {
   const extras = resolve(KnownToken.Http.Handler.Response.specificExtras);
   const Helmet = resolve(KnownToken.Http.Handler.Page.helmet);
   const { req, res } = resolve(KnownToken.ExpressHandler.context);
+  const abortController = resolve(KnownToken.Http.Fetch.abortController);
 
   const getAssets = typeof assetsInit === 'function' ? assetsInit : () => assetsInit;
 
@@ -104,7 +64,7 @@ export function provideHandlerMain(resolve: Resolve): VoidFunction {
         </HelmetContext.Provider>
       );
 
-      switch (getResponseFormat(req)) {
+      switch (getPageResponseFormat(req)) {
         case 'html': {
           res.setHeader('simaland-bundle-js', assets.js);
           res.setHeader('simaland-bundle-css', assets.css);
@@ -159,6 +119,8 @@ export function provideHandlerMain(resolve: Resolve): VoidFunction {
 
       res.status(statusCode).send(message);
       logger.error(error);
+    } finally {
+      abortController.abort();
     }
   };
 }
@@ -185,9 +147,131 @@ export function providePageHelmet(resolve: Resolve) {
   const config = resolve(KnownToken.Config.base);
   const { req } = resolve(KnownToken.ExpressHandler.context);
 
-  return config.env === 'development' && getResponseFormat(req) === 'html'
+  return config.env === 'development' && getPageResponseFormat(req) === 'html'
     ? RegularHelmet
     : Fragment;
+}
+
+/**
+ * Провайдер промежуточных слоев для fetch.
+ * @param resolve Функция для получения зависимости по токену.
+ * @return Массив промежуточных слоев.
+ */
+export function provideFetchMiddleware(resolve: Resolve): Middleware[] {
+  const config = resolve(KnownToken.Config.base);
+  const logger = resolve(KnownToken.logger);
+  const tracer = resolve(KnownToken.Tracing.tracer);
+  const context = resolve(KnownToken.ExpressHandler.context);
+  const cookieStore = resolve(KnownToken.Http.Fetch.cookieStore);
+  const abortController = resolve(KnownToken.Http.Fetch.abortController);
+
+  const logging = new FetchLogging(logger);
+
+  abortController.signal.addEventListener(
+    'abort',
+    () => {
+      logging.disabled = true;
+    },
+    { capture: true },
+  );
+
+  return [
+    // ВАЖНО: слой логирования ошибки ПЕРЕД остальными слоями чтобы не упустить ошибки выше
+    log({
+      onCatch: data => logging.onCatch(data),
+    }),
+
+    (request, next) => {
+      const innerController = new AbortController();
+
+      abortController.signal.addEventListener('abort', () => {
+        innerController.abort();
+      });
+
+      request.signal?.addEventListener('abort', () => {
+        innerController.abort();
+      });
+
+      return next(new Request(request, { signal: innerController.signal }));
+    },
+
+    cookie(cookieStore),
+
+    defaultHeaders(getForwardedHeadersExpress(config, context.req)),
+
+    tracingMiddleware(tracer, context.res.locals.tracing.rootContext),
+
+    // ВАЖНО: слой логирования запроса и ответа ПОСЛЕ остальных слоев чтобы использовать актуальные данные
+    log({
+      onRequest: data => logging.onRequest(data),
+      onResponse: data => logging.onResponse(data),
+    }),
+  ];
+}
+
+/**
+ * Провайдер фабрики http-клиентов.
+ * @param resolve Функция для получения зависимости по токену.
+ * @return Фабрика.
+ */
+export function provideAxiosFactory(resolve: Resolve) {
+  // @todo а что если привести все зависимости к виду:
+  // const getAppConfig = resolve.lazy(KnownToken.Config.base);
+
+  const appConfig = resolve(KnownToken.Config.base);
+  const tracer = resolve(KnownToken.Tracing.tracer);
+  const context = resolve(KnownToken.ExpressHandler.context);
+  const logHandler = resolve(KnownToken.Axios.Middleware.Log.handler);
+  const abortController = resolve(KnownToken.Http.Fetch.abortController);
+  const cookieStore = resolve(KnownToken.Http.Fetch.cookieStore);
+
+  // @todo добавить при необходимости (но тогда в логе будет значительно больше ошибок)
+  // можно не отсылать ошибки из клиента если ответ от сервера уже ушел (writableEnded)
+  // const controller = new AbortController();
+  // context.res.on('finish', () => {
+  //   controller.abort();
+  // });
+
+  // @todo унести в провайдер стора кук
+  // cookieStore.subscribe(() => {
+  //   if (!context.res.writableEnded) {
+  //     context.res.setHeader('set-cookie', cookieStore.getCookies());
+  //   }
+  // });
+
+  return (config: CreateAxiosDefaults = {}) => {
+    const client = create({
+      ...config,
+      headers: {
+        ...getForwardedHeadersExpress(appConfig, context.req),
+
+        // @todo убрать as any
+        ...(config.headers as any),
+      },
+    });
+
+    // @todo объединить сигналы из аргумента request и из провайдера
+    client.use(async (requestConfig, next) => {
+      const innerController = new AbortController();
+
+      abortController.signal.addEventListener('abort', () => {
+        innerController.abort();
+      });
+
+      requestConfig.signal?.addEventListener?.('abort', () => {
+        innerController.abort();
+      });
+
+      next({ ...requestConfig, signal: innerController.signal });
+    });
+
+    client.use(HttpStatus.axiosMiddleware());
+    client.use(tracingMiddlewareAxios(tracer, context.res.locals.tracing.rootContext));
+    client.use(logMiddleware(logHandler));
+    client.use(cookieMiddleware(cookieStore));
+
+    return client;
+  };
 }
 
 /**
@@ -211,4 +295,15 @@ export function provideSpecificParams(resolve: Resolve): Record<string, unknown>
   } catch {
     return {};
   }
+}
+
+/**
+ * Провайдер хранилища cookie для исходящих запросов.
+ * @param resolve Функция для получения зависимости по токену.
+ * @return Хранилище cookie.
+ */
+export function provideCookieStore(resolve: Resolve) {
+  const context = resolve(KnownToken.ExpressHandler.context);
+
+  return createCookieStore(context.req.header('cookie'));
 }

--- a/src/preset/node/handler/utils/index.tsx
+++ b/src/preset/node/handler/utils/index.tsx
@@ -80,7 +80,7 @@ export class SpecificExtras {
  * @param req Запрос.
  * @return Формат.
  */
-export function getResponseFormat(req: Request): 'html' | 'json' {
+export function getPageResponseFormat(req: Request): 'html' | 'json' {
   let result: 'html' | 'json' = 'html';
 
   if ((req.header('accept') || '').toLowerCase().includes('application/json')) {

--- a/src/preset/node/node/index.ts
+++ b/src/preset/node/node/index.ts
@@ -1,5 +1,5 @@
 import { KnownToken } from '../../../tokens';
-import { provideBaseConfig } from '../../isomorphic/providers';
+import { provideBaseConfig, provideFetch } from '../../isomorphic/providers';
 import { Preset, createPreset } from '../../../di';
 import { PresetTuner } from '../../isomorphic/types';
 import { healthCheck } from '../../../utils/express/handler/health-check';
@@ -47,10 +47,14 @@ export function PresetNode(customize?: PresetTuner): Preset {
   // metrics
   preset.set(KnownToken.Metrics.httpApp, provideMetricsHttpApp);
 
-  // http client
+  // fetch
+  preset.set(KnownToken.Http.fetch, provideFetch);
+  preset.set(KnownToken.Http.Fetch.middleware, () => []);
+
+  // axios
   preset.set(KnownToken.Axios.factory, provideAxiosFactory);
 
-  // http server
+  // express
   preset.set(KnownToken.Express.factory, provideExpressFactory);
   preset.set(KnownToken.Express.Handlers.healthCheck, healthCheck);
   preset.set(KnownToken.Express.Middleware.request, provideExpressRequestMiddleware);

--- a/src/preset/node/node/providers/index.ts
+++ b/src/preset/node/node/providers/index.ts
@@ -7,7 +7,7 @@ import { createSentryHandler } from '../../../../log/handler/sentry';
 import { HttpApiHostPool } from '../../../isomorphic/utils';
 import { KnownToken } from '../../../../tokens';
 import { Resolve } from '../../../../di';
-import { StrictMap, KnownHttpApiKey } from '../../../isomorphic/types';
+import { KnownHttpApiKey } from '../../../isomorphic/types';
 import { toMilliseconds } from '../../../../utils';
 import { RESPONSE_EVENT_TYPE } from '../../../isomorphic/constants';
 import { getClientIp } from '../utils/http-server';
@@ -400,7 +400,7 @@ export function provideSsrBridgeServerSide(resolve: Resolve): BridgeServerSide {
  * @param resolve Функция для получения зависимости по токену.
  * @return Пул известных http-хостов.
  */
-export function provideKnownHttpApiHosts(resolve: Resolve): StrictMap<KnownHttpApiKey> {
+export function provideKnownHttpApiHosts(resolve: Resolve): HttpApiHostPool<KnownHttpApiKey> {
   const source = resolve(KnownToken.Config.source);
 
   return new HttpApiHostPool(
@@ -409,6 +409,7 @@ export function provideKnownHttpApiHosts(resolve: Resolve): StrictMap<KnownHttpA
       simaV3: 'API_URL_SIMALAND_V3',
       simaV4: 'API_URL_SIMALAND_V4',
       simaV6: 'API_URL_SIMALAND_V6',
+      chponkiV2: 'API_URL_CHPONKI_V2',
     },
     source,
   );

--- a/src/preset/node/node/utils/http-client/index.ts
+++ b/src/preset/node/node/utils/http-client/index.ts
@@ -1,6 +1,6 @@
 import type { AxiosDefaults, AxiosRequestConfig } from 'axios';
 import type { Middleware } from 'middleware-axios';
-import type { Request } from 'express';
+import type express from 'express';
 import { Context, Tracer, SpanStatusCode } from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { BaseConfig } from '../../../../../config';
@@ -101,7 +101,10 @@ export function hideFirstId(url: string): [string, number | undefined] {
  * @param request Входящий запрос.
  * @return Заголовки для исходящих запросов.
  */
-export function getForwardedHeaders(config: BaseConfig, request: Request): Record<string, string> {
+export function getForwardedHeaders(
+  config: BaseConfig,
+  request: express.Request,
+): Record<string, string> {
   const result: Record<string, string> = {
     'User-Agent': `simaland-${config.appName}/${config.appVersion}`,
   };

--- a/src/preset/server/utils/index.ts
+++ b/src/preset/server/utils/index.ts
@@ -1,0 +1,106 @@
+import type { BaseConfig } from '../../../config';
+import type { Middleware } from '../../../http';
+import { SpanStatusCode, type Context, type Tracer } from '@opentelemetry/api';
+import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { hideFirstId } from '../../node/node/utils/http-client';
+
+/**
+ * Определяет формат ответа для страницы (html-верстки).
+ * Вернет "json" - если заголовок запроса "accept" содержит "application/json".
+ * Вернет "html" во всех остальных случаях.
+ * @param request Запрос.
+ * @return Формат.
+ */
+export function getPageResponseFormat(request: Request): 'html' | 'json' {
+  let result: 'html' | 'json' = 'html';
+
+  if ((request.headers.get('accept') || '').toLowerCase().includes('application/json')) {
+    result = 'json';
+  }
+
+  return result;
+}
+
+/**
+ * Вернет заголовки, которые должны содержаться в исходящих http-запросах при обработке входящего http-запроса.
+ * @param config Конфигурация.
+ * @param request Входящий запрос.
+ * @return Заголовки.
+ */
+export function getForwardedHeaders(config: BaseConfig, request: Request): Headers {
+  const result = new Headers();
+
+  // user agent
+  result.set('User-Agent', `simaland-${config.appName}/${config.appVersion}`);
+
+  // client ip
+  const clientIp = getClientIp(request);
+
+  if (clientIp) {
+    result.set('X-Client-Ip', clientIp);
+  }
+
+  // service headers
+  request.headers.forEach((headerValue, headerName) => {
+    if (
+      headerName.toLowerCase().startsWith('simaland-') &&
+      headerName.toLowerCase() !== 'simaland-params'
+    ) {
+      result.set(headerName, headerValue);
+    }
+  });
+
+  return result;
+}
+
+/**
+ * Вернет строку с IP на основе заголовков запроса.
+ * @param request Запрос.
+ * @return IP или null.
+ */
+export function getClientIp(request: Request): string | null {
+  const headerValue = request.headers.get('x-client-ip') || request.headers.get('x-forwarded-for');
+
+  return headerValue;
+}
+
+/**
+ * Вернет новый промежуточный слой трассировки для fetch.
+ * @param tracer Трассировщик.
+ * @param rootContext Контекст.
+ * @return Промежуточный слой трассировки.
+ */
+export function tracingMiddleware(tracer: Tracer, rootContext: Context): Middleware {
+  return async (request, next) => {
+    const [url, foundId] = hideFirstId(new URL(request.url).pathname);
+    const span = tracer.startSpan(`HTTP ${request.method} ${url}`, undefined, rootContext);
+
+    span.setAttributes({
+      [SemanticAttributes.HTTP_URL]: url,
+      [SemanticAttributes.HTTP_METHOD]: request.method,
+      'request.params': JSON.stringify(new URL(request.url).searchParams),
+      'request.headers': JSON.stringify(request.headers),
+
+      // если нашли id - добавляем в теги
+      ...(foundId && { 'request.id': foundId }),
+    });
+
+    try {
+      const response = await next(request);
+
+      span.end();
+
+      return response;
+    } catch (error) {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: 'HTTP Request failed',
+      });
+
+      span.end();
+
+      // не прячем ошибку
+      throw error;
+    }
+  };
+}

--- a/src/preset/web/index.ts
+++ b/src/preset/web/index.ts
@@ -5,6 +5,7 @@ import {
   provideBaseConfig,
   provideReduxMiddlewareSaga,
   provideAxiosLogHandler,
+  provideFetch,
 } from '../isomorphic/providers';
 import {
   provideBridgeClientSide,
@@ -12,6 +13,7 @@ import {
   provideAxiosFactory,
   provideKnownHttpApiHosts,
   provideLogger,
+  provideFetchMiddleware,
 } from './providers';
 
 /**
@@ -31,6 +33,8 @@ export function PresetWeb(customize?: PresetTuner): Preset {
   preset.set(KnownToken.Axios.Middleware.Log.handler, provideAxiosLogHandler);
   preset.set(KnownToken.SsrBridge.clientSide, provideBridgeClientSide);
   preset.set(KnownToken.Http.Api.knownHosts, provideKnownHttpApiHosts);
+  preset.set(KnownToken.Http.fetch, provideFetch);
+  preset.set(KnownToken.Http.Fetch.middleware, provideFetchMiddleware);
 
   if (customize) {
     customize({ override: preset.set.bind(preset) });

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -12,12 +12,13 @@ import type { Tracer } from '@opentelemetry/api';
 import type { BasicTracerProvider, SpanExporter } from '@opentelemetry/sdk-trace-base';
 import type { Resource } from '@opentelemetry/resources';
 import type { ElementType, ReactNode } from 'react';
-import type { KnownHttpApiKey, PageAssets, StrictMap } from './preset/isomorphic/types';
+import type { KnownHttpApiKey, PageAssets } from './preset/isomorphic/types';
 import type { HandlerContext } from './preset/node/types';
 import type { SpecificExtras } from './preset/node/handler/utils';
 import type { CreateAxiosDefaults } from 'axios';
 import type { AxiosInstanceWrapper, Middleware as AxiosMiddleware } from 'middleware-axios';
-import type { Handler, Middleware } from './http';
+import type { CookieStore, Handler, Middleware } from './http';
+import type { HttpApiHostPool } from './preset/isomorphic/utils';
 
 export const KnownToken = {
   // config
@@ -50,12 +51,13 @@ export const KnownToken = {
   // http
   Http: {
     Api: {
-      knownHosts: createToken<StrictMap<KnownHttpApiKey>>('http/api/known-hosts'),
+      knownHosts: createToken<HttpApiHostPool<KnownHttpApiKey>>('http/api/known-hosts'),
     },
 
     fetch: createToken<typeof fetch>('fetch'),
     Fetch: {
       abortController: createToken<AbortController>('fetch/abort-controller'),
+      cookieStore: createToken<CookieStore>('fetch/cookie-store'),
       middleware: createToken<Middleware[]>('fetch/middleware'),
     },
 

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -16,7 +16,7 @@ import type { KnownHttpApiKey, PageAssets, StrictMap } from './preset/isomorphic
 import type { HandlerContext } from './preset/node/types';
 import type { SpecificExtras } from './preset/node/handler/utils';
 import type { CreateAxiosDefaults } from 'axios';
-import type { AxiosInstanceWrapper } from 'middleware-axios';
+import type { AxiosInstanceWrapper, Middleware as AxiosMiddleware } from 'middleware-axios';
 import type { Handler, Middleware } from './http';
 
 export const KnownToken = {
@@ -85,9 +85,10 @@ export const KnownToken = {
   // axios
   Axios: {
     factory: createToken<(config?: CreateAxiosDefaults) => AxiosInstanceWrapper>('axios/factory'),
+    middleware: createToken<AxiosMiddleware<any>[]>('axios/middleware'),
     Middleware: {
       Log: {
-        handler: createToken<LogMiddlewareHandlerInit>('express/middleware/log/handler'),
+        handler: createToken<LogMiddlewareHandlerInit>('axios/middleware/log/handler'),
       },
     },
   },


### PR DESCRIPTION
- tokens: добавлен токен промежуточных слоев для axios (minor)
- preset/isomorphic: добавлены провайдеры fetch, axios.create, AbortController (minor)
- preset/bun/handler: правки (patch)
- preset/bun/bun: правки (patch)
- HttpApiHostPool: добавлена опция absolute для удобного приведения пути к абсолютному в браузере (minor)
- tokens: knownHosts теперь содержит интерфейс HttpApiHostPool<KnownHttpApiKey> (patch)
- tokens: добавлен токен для CookieStore для fetch/axios
- preset/web: добавлено отображение событий логгера error/debug в консоль при NODE_ENV=development (minor)
- preset/web: добавлены провайдеры fetch и fetchMiddleware (minor)
- preset/server: добавлены изоморфные серверные утилиты (minor)
- preset/node: добавлены провайдеры fetch и fetchMiddleware (minor)
- preset/isomorphic: KnownHttpApiKey теперь содержит хост для чпонек v2
- preset/node/handler: getResponseFormat переименован в getPageResponseFormat (major)
- preset/node/handler: добавлены провайдеры fetch и fetchMiddleware (minor)
- preset/node/handler: аксиос теперь учитывает signal (minor)
- preset/bun: многочисленные доработки (patch)