### PR TITLE
 Шаг 56 #38 

### DIFF
--- a/src/preset/bun/bun/index.ts
+++ b/src/preset/bun/bun/index.ts
@@ -21,7 +21,7 @@ export function PresetBun(customize?: PresetTuner) {
   // @todo
 
   // metrics
-  // @todo
+  preset.set(KnownToken.Metrics.httpHandler, BunProviders.serveMetrics);
 
   // http fetch
   preset.set(KnownToken.Http.fetch, BunProviders.fetch);

--- a/src/preset/bun/bun/providers/index.ts
+++ b/src/preset/bun/bun/providers/index.ts
@@ -3,7 +3,7 @@ import { Resolve } from '../../../../di';
 import { KnownToken } from '../../../../tokens';
 import { ConfigSource, createConfigSource } from '../../../../config';
 import { Logger, createLogger } from '../../../../log';
-import { Handler, Middleware, applyMiddleware, log } from '../../../../http';
+import { Handler, Middleware, log } from '../../../../http';
 import { ServeLogging } from '../utils';
 import { providePinoHandler } from '../../../node/node/providers';
 import { route, router } from '@krutoo/fetch-tools';
@@ -11,6 +11,10 @@ import { getCurrentHub, init, runWithAsyncContext } from '@sentry/bun';
 import { createSentryHandler } from '../../../../log/handler/sentry';
 import { healthCheck } from '../../../isomorphic/utils';
 import { provideFetch } from '../../../isomorphic/providers';
+import { toMilliseconds } from '../../../../utils';
+import { ServerMiddleware } from '../../../server/types';
+import { applyServerMiddleware } from '../../../server/utils';
+import PromClient from 'prom-client';
 
 export const BunProviders = {
   configSource(): ConfigSource {
@@ -54,21 +58,64 @@ export const BunProviders = {
     const middleware = resolve(KnownToken.Http.Serve.middleware);
     const routes = resolve(KnownToken.Http.Serve.routes);
 
-    const enhance = applyMiddleware(...middleware);
+    const enhance = applyServerMiddleware(...middleware);
 
     return router(
       // маршруты с промежуточными слоями
-      ...routes.map(([pathname, handler]) => route(pathname, enhance(handler))),
+      ...routes.map(([pathname, handler]) => {
+        const enhanced = enhance(handler);
+        return route(pathname, request => enhanced(request, { events: new EventTarget() }));
+      }),
+
+      // @todo вместо routes обрабатывать pageRoutes с помощью route.get() из новой версии fetch-tools (для явности)
+      // @todo также добавить apiRoutes и обрабатывать их с помощью с помощью route()?
 
       // служебные маршруты (без промежуточных слоев)
       route('/healthcheck', healthCheck()),
     );
   },
 
-  serveMiddleware(resolve: Resolve): Middleware[] {
+  serveMiddleware(resolve: Resolve): ServerMiddleware[] {
+    const config = resolve(KnownToken.Config.base);
     const logger = resolve(KnownToken.logger);
 
     const logging = new ServeLogging(logger);
+
+    // @todo перенести в preset/server
+    const ConventionalLabels = {
+      HTTP_RESPONSE: ['version', 'route', 'code', 'method'],
+      SSR: ['version', 'route', 'method'],
+    } as const;
+
+    const requestCount = new PromClient.Counter({
+      name: 'http_request_count',
+      help: 'Incoming HTTP request count',
+      labelNames: ConventionalLabels.HTTP_RESPONSE,
+    });
+
+    const responseDuration = new PromClient.Histogram({
+      name: 'http_response_duration_ms',
+      help: 'Duration of incoming HTTP requests in ms',
+      labelNames: ConventionalLabels.HTTP_RESPONSE,
+      buckets: [30, 100, 200, 500, 1000, 2500, 5000, 10000],
+    });
+
+    const renderDuration = new PromClient.Histogram({
+      name: 'render_duration_ms',
+      help: 'Duration of SSR ms',
+      labelNames: ConventionalLabels.SSR,
+      buckets: [0.1, 15, 50, 100, 250, 500, 800, 1500],
+    });
+
+    const getLabels = (
+      req: Request,
+      res: Response,
+    ): Record<(typeof ConventionalLabels.HTTP_RESPONSE)[number], string | number> => ({
+      version: config.appVersion,
+      route: req.url,
+      code: res.status,
+      method: req.method,
+    });
 
     return [
       // ВАЖНО: изолируем хлебные крошки чтобы они группировались по входящим запросам
@@ -79,7 +126,49 @@ export const BunProviders = {
         onCatch: data => logging.onRequest(data),
       }),
 
-      // @todo metrics, tracing
+      // @todo tracing
+
+      async (request, next, context) => {
+        const responseStart = process.hrtime.bigint();
+        let renderStart = 0n;
+
+        context.events.addEventListener(
+          'render:start',
+          () => {
+            renderStart = process.hrtime.bigint();
+          },
+          { once: true },
+        );
+
+        context.events.addEventListener(
+          'render:finish',
+          () => {
+            const renderFinish = process.hrtime.bigint();
+
+            renderDuration.observe(
+              {
+                version: config.appVersion,
+                method: request.method,
+                route: request.url,
+              },
+              toMilliseconds(renderFinish - renderStart),
+            );
+          },
+          { once: true },
+        );
+
+        const response = await next(request);
+        const responseFinish = process.hrtime.bigint();
+
+        responseDuration.observe(
+          getLabels(request, response),
+          toMilliseconds(responseFinish - responseStart),
+        );
+
+        requestCount.inc(getLabels(request, response), 1);
+
+        return response;
+      },
 
       // ВАЖНО: слой логирования запроса и ответа ПОСЛЕ остальных слоев чтобы использовать актуальные данные
       log({
@@ -87,5 +176,20 @@ export const BunProviders = {
         onResponse: data => logging.onResponse(data),
       }),
     ];
+  },
+
+  serveMetrics(): Handler {
+    // @todo задействовать когда Bun реализует pref_hooks.monitorEventLoopDelay (https://github.com/siimon/prom-client/issues/570)
+    // PromClient.collectDefaultMetrics();
+
+    // @todo здесь или в другом компоненте надо проверять путь и метод запроса
+    return async () => {
+      const metrics = await PromClient.register.metrics();
+      const headers = new Headers();
+
+      headers.set('Content-Type', PromClient.register.contentType);
+
+      return new Response(metrics, { headers });
+    };
   },
 } as const;

--- a/src/preset/bun/handler/utils/index.ts
+++ b/src/preset/bun/handler/utils/index.ts
@@ -1,19 +1,19 @@
 /* eslint-disable require-jsdoc, jsdoc/require-jsdoc */
-import type { Handler } from '../../../../http';
+import type { ServerHandler } from '../../../server/types';
 import { KnownToken } from '../../../../tokens';
 import { CURRENT_APP, type Application, type Resolve } from '../../../../di';
 
 export function HandlerProvider(getApp: () => Application) {
-  return (resolve: Resolve): Handler => {
+  return (resolve: Resolve): ServerHandler => {
     const parent = resolve(CURRENT_APP);
 
-    return request => {
+    return (request, context) => {
       const app = getApp();
 
       app.attach(parent);
-      app.bind(KnownToken.Http.Handler.context).toValue({ request });
+      app.bind(KnownToken.Http.Handler.context).toValue({ request, ...context });
 
-      return app.get(KnownToken.Http.Handler.main)(request);
+      return app.get(KnownToken.Http.Handler.main)(request, context);
     };
   };
 }

--- a/src/preset/node/handler/providers/index.tsx
+++ b/src/preset/node/handler/providers/index.tsx
@@ -12,7 +12,7 @@ import type { Resolve } from '../../../../di';
 import { KnownToken } from '../../../../tokens';
 import {
   getForwardedHeaders as getForwardedHeadersExpress,
-  tracingMiddleware as tracingMiddlewareAxios,
+  axiosTracingMiddleware,
 } from '../../node/utils/http-client';
 import type { Middleware as AxiosMiddleware } from 'middleware-axios';
 import { AxiosLogging, FetchLogging, HttpStatus } from '../../../isomorphic/utils';
@@ -22,7 +22,7 @@ import type { ConventionalJson } from '../../../isomorphic/types';
 import { Fragment } from 'react';
 import { HelmetContext, RegularHelmet, getPageResponseFormat } from '../utils';
 import { renderToString } from 'react-dom/server';
-import { tracingMiddleware } from '../../../server/utils';
+import { fetchTracingMiddleware } from '../../../server/utils';
 
 /**
  * Провайдер главной функции обработчика входящего http-запроса.
@@ -201,7 +201,7 @@ export function provideFetchMiddleware(resolve: Resolve): Middleware[] {
 
     cookie(cookieStore),
 
-    tracingMiddleware(tracer, context.res.locals.tracing.rootContext),
+    fetchTracingMiddleware(tracer, context.res.locals.tracing.rootContext),
 
     // ВАЖНО: слой логирования запроса и ответа ПОСЛЕ остальных слоев чтобы использовать актуальные данные
     log(initData => {
@@ -280,7 +280,7 @@ export function provideAxiosMiddleware(resolve: Resolve): AxiosMiddleware<any>[]
     },
 
     HttpStatus.axiosMiddleware(),
-    tracingMiddlewareAxios(tracer, context.res.locals.tracing.rootContext),
+    axiosTracingMiddleware(tracer, context.res.locals.tracing.rootContext),
     logMiddleware(logHandler),
     cookieMiddleware(cookieStore),
   ];

--- a/src/preset/node/index.ts
+++ b/src/preset/node/index.ts
@@ -1,3 +1,3 @@
-export type { HandlerContext } from './types';
+export type { ExpressHandlerContext } from './types';
 export { PresetNode } from './node';
 export { PresetHandler, HandlerProvider } from './handler';

--- a/src/preset/node/node/utils/http-client/__test__/index.test.ts
+++ b/src/preset/node/node/utils/http-client/__test__/index.test.ts
@@ -1,11 +1,11 @@
 import { Context } from '@opentelemetry/api';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { Span, Tracer } from '@opentelemetry/sdk-trace-base';
-import { tracingMiddleware, getRequestInfo, hideFirstId, getForwardedHeaders } from '..';
+import { axiosTracingMiddleware, getRequestInfo, hideFirstId, getForwardedHeaders } from '..';
 import { BaseConfig } from '../../../../../../config';
 import { Request } from 'express';
 
-describe('tracingMiddleware', () => {
+describe('axiosTracingMiddleware', () => {
   it('should handle success response', async () => {
     let currentSpan: Span = null as any;
 
@@ -25,7 +25,7 @@ describe('tracingMiddleware', () => {
 
     const context: Context = {} as any;
 
-    const middleware = tracingMiddleware(tracer, context);
+    const middleware = axiosTracingMiddleware(tracer, context);
 
     expect(currentSpan).toBe(null);
 
@@ -58,7 +58,7 @@ describe('tracingMiddleware', () => {
 
     const context: Context = {} as any;
 
-    const middleware = tracingMiddleware(tracer, context);
+    const middleware = axiosTracingMiddleware(tracer, context);
 
     expect(currentSpan).toBe(null);
 

--- a/src/preset/node/node/utils/http-client/index.ts
+++ b/src/preset/node/node/utils/http-client/index.ts
@@ -13,7 +13,7 @@ import { displayUrl } from '../../../../isomorphic/utils';
  * @param rootContext Контекст.
  * @return Middleware.
  */
-export function tracingMiddleware(tracer: Tracer, rootContext: Context): Middleware<any> {
+export function axiosTracingMiddleware(tracer: Tracer, rootContext: Context): Middleware<any> {
   return async function trace(config, next, defaults) {
     const { method, url, foundId } = getRequestInfo(config, defaults);
     const span = tracer.startSpan(`HTTP ${method} ${url}`, undefined, rootContext);
@@ -114,7 +114,7 @@ export function getForwardedHeaders(
     result['X-Client-Ip'] = clientIp;
   }
 
-  const cookie = request.get('cookie');
+  const cookie = request.header('cookie');
   if (cookie) {
     result.Cookie = cookie;
   }

--- a/src/preset/node/node/utils/http-server/index.ts
+++ b/src/preset/node/node/utils/http-server/index.ts
@@ -8,8 +8,8 @@ import net from 'node:net';
  */
 export function getClientIp(request: Request): string | undefined {
   const headerValue =
-    request.get('x-client-ip') ||
-    request.get('x-forwarded-for') ||
+    request.header('x-client-ip') ||
+    request.header('x-forwarded-for') ||
     request.socket.remoteAddress ||
     '';
 

--- a/src/preset/node/node/utils/index.ts
+++ b/src/preset/node/node/utils/index.ts
@@ -1,2 +1,2 @@
-export { tracingMiddleware } from './http-client';
+export { axiosTracingMiddleware } from './http-client';
 export { getClientIp } from './http-server';

--- a/src/preset/node/types.ts
+++ b/src/preset/node/types.ts
@@ -3,7 +3,7 @@ import type { Request, Response, NextFunction } from 'express';
 /**
  * Контекст обработчика express.
  */
-export interface HandlerContext {
+export interface ExpressHandlerContext {
   req: Request;
   res: Response;
   next: NextFunction;

--- a/src/preset/server/types.ts
+++ b/src/preset/server/types.ts
@@ -1,0 +1,23 @@
+/**
+ * На сервере между промежуточными слоями надо обмениваться данными поэтому появился такой интерфейс.
+ * Возможно в будущем он перейдет в `@krutoo/fetch-tools`.
+ */
+export interface ServerHandlerContext {
+  events: EventTarget;
+}
+
+export interface ServerHandler {
+  (request: Request, context: ServerHandlerContext): Response | Promise<Response>;
+}
+
+export interface ServerEnhancer {
+  (request: ServerHandler): ServerHandler;
+}
+
+export interface ServerMiddleware {
+  (
+    request: Request,
+    next: (req: Request, ctx?: ServerHandlerContext) => Response | Promise<Response>,
+    context: ServerHandlerContext,
+  ): Response | Promise<Response>;
+}

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -13,12 +13,13 @@ import type { BasicTracerProvider, SpanExporter } from '@opentelemetry/sdk-trace
 import type { Resource } from '@opentelemetry/resources';
 import type { ElementType, ReactNode } from 'react';
 import type { KnownHttpApiKey, PageAssets } from './preset/isomorphic/types';
-import type { HandlerContext } from './preset/node/types';
+import type { ExpressHandlerContext } from './preset/node/types';
 import type { SpecificExtras } from './preset/node/handler/utils';
 import type { CreateAxiosDefaults } from 'axios';
 import type { AxiosInstanceWrapper, Middleware as AxiosMiddleware } from 'middleware-axios';
 import type { CookieStore, Handler, LogHandler, LogHandlerFactory, Middleware } from './http';
 import type { HttpApiHostPool } from './preset/isomorphic/utils';
+import type { ServerHandlerContext, ServerHandler, ServerMiddleware } from './preset/server/types';
 
 export const KnownToken = {
   // config
@@ -46,6 +47,7 @@ export const KnownToken = {
   // metrics
   Metrics: {
     httpApp: createToken<express.Application>('metrics/http-app'),
+    httpHandler: createToken<Handler>('metrics/http-handler'),
   },
 
   // http
@@ -68,13 +70,13 @@ export const KnownToken = {
 
     serve: createToken<Handler>('serve'),
     Serve: {
-      routes: createToken<Array<[string, Handler]>>('serve/routes'),
-      middleware: createToken<Middleware[]>('serve/middleware'),
+      routes: createToken<Array<[string, ServerHandler]>>('serve/routes'),
+      middleware: createToken<ServerMiddleware[]>('serve/middleware'),
     },
 
     Handler: {
-      main: createToken<Handler>('handler/main'),
-      context: createToken<{ request: Request }>('handler/context'),
+      main: createToken<ServerHandler>('handler/main'),
+      context: createToken<ServerHandlerContext & { request: Request }>('handler/context'),
       Request: {
         specificParams: createToken<Record<string, unknown>>('request/specific-params'),
       },
@@ -118,7 +120,7 @@ export const KnownToken = {
   // express handler
   ExpressHandler: {
     main: createToken<() => void>('express-handler/main'),
-    context: createToken<HandlerContext>('express-handler/context'),
+    context: createToken<ExpressHandlerContext>('express-handler/context'),
   },
 
   // redux


### PR DESCRIPTION
- tokens: добавлен токен Metrics.httpHandler (minor)
- preset/server: добавлены типы-обертки над Handler, Middleware, Enhancer для передачи контекста обработчика на сервере (minor)
- tokens: токены сервера теперь используют расширенные типы (minor)
- preset/node: HandlerContext переименован в ExpressHandlerContext (major)
- preset/bun: добавлены метрики входящих запросов но без стандартных метрик (minor)
- preset/node/utils: tracingMiddleware переименована в axiosTracingMiddleware