### PR TITLE
Шаг 58 #38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/env": "^2.2.2",
-        "@krutoo/fetch-tools": "^0.0.11",
+        "@krutoo/fetch-tools": "^0.0.12",
         "@opentelemetry/api": "^1.4.1",
         "@opentelemetry/exporter-prometheus": "^0.38.0",
         "@opentelemetry/exporter-trace-otlp-http": "^0.39.1",
@@ -3671,9 +3671,9 @@
       }
     },
     "node_modules/@krutoo/fetch-tools": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@krutoo/fetch-tools/-/fetch-tools-0.0.11.tgz",
-      "integrity": "sha512-AnXjfbhcVCq1n3gcb2oIaxjppEhmFy4FA94U3wOUT/Hgq44XCA5jS6MyTdNwKskn0y8vJTQAeUC2unW++bgR7A=="
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@krutoo/fetch-tools/-/fetch-tools-0.0.12.tgz",
+      "integrity": "sha512-qooqX0k7DoJF49j/9X6WnveUPpjSwlvBdko2LIrV2BcUhezZZ+a4etBs8gKMmaPZytZ7xF/JuFVlk4O7f8zjxA=="
     },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
@@ -18477,9 +18477,9 @@
       }
     },
     "@krutoo/fetch-tools": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@krutoo/fetch-tools/-/fetch-tools-0.0.11.tgz",
-      "integrity": "sha512-AnXjfbhcVCq1n3gcb2oIaxjppEhmFy4FA94U3wOUT/Hgq44XCA5jS6MyTdNwKskn0y8vJTQAeUC2unW++bgR7A=="
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@krutoo/fetch-tools/-/fetch-tools-0.0.12.tgz",
+      "integrity": "sha512-qooqX0k7DoJF49j/9X6WnveUPpjSwlvBdko2LIrV2BcUhezZZ+a4etBs8gKMmaPZytZ7xF/JuFVlk4O7f8zjxA=="
     },
     "@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@humanwhocodes/env": "^2.2.2",
-    "@krutoo/fetch-tools": "^0.0.11",
+    "@krutoo/fetch-tools": "^0.0.12",
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/exporter-prometheus": "^0.38.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.39.1",
@@ -146,6 +146,12 @@
       "require": "./dist/cjs/preset/web/providers/index.js",
       "import": "./dist/esm/preset/web/providers/index.js",
       "default": "./dist/esm/preset/web/providers/index.js"
+    },
+    "./preset/server": {
+      "types": "./dist/types/preset/server/index.d.ts",
+      "require": "./dist/cjs/preset/server/index.js",
+      "import": "./dist/esm/preset/server/index.js",
+      "default": "./dist/esm/preset/server/index.js"
     },
     "./preset/node": {
       "types": "./dist/types/preset/node/index.d.ts",
@@ -278,6 +284,9 @@
       ],
       "preset/web/providers": [
         "./dist/types/preset/web/providers/index.d.ts"
+      ],
+      "preset/server": [
+        "./dist/types/preset/server/index.d.ts"
       ],
       "preset/node": [
         "./dist/types/preset/node/index.d.ts"

--- a/src/preset/bun/bun/index.ts
+++ b/src/preset/bun/bun/index.ts
@@ -29,6 +29,7 @@ export function PresetBun(customize?: PresetTuner) {
 
   // http serve
   preset.set(KnownToken.Http.serve, BunProviders.serve);
+  preset.set(KnownToken.Http.Serve.serviceRoutes, BunProviders.serviceRoutes);
   preset.set(KnownToken.Http.Serve.middleware, BunProviders.serveMiddleware);
 
   // http api

--- a/src/preset/bun/handler/providers/index.tsx
+++ b/src/preset/bun/handler/providers/index.tsx
@@ -193,13 +193,21 @@ export const HandlerProviders = {
       (request, next) => {
         const innerController = new AbortController();
 
-        request.signal?.addEventListener('abort', () => {
-          innerController.abort();
-        });
+        request.signal?.addEventListener(
+          'abort',
+          () => {
+            innerController.abort();
+          },
+          { once: true },
+        );
 
-        abortController.signal.addEventListener('abort', () => {
-          innerController.abort();
-        });
+        abortController.signal.addEventListener(
+          'abort',
+          () => {
+            innerController.abort();
+          },
+          { once: true },
+        );
 
         return next(new Request(request, { signal: innerController.signal }));
       },

--- a/src/preset/bun/handler/utils/index.ts
+++ b/src/preset/bun/handler/utils/index.ts
@@ -1,9 +1,9 @@
 /* eslint-disable require-jsdoc, jsdoc/require-jsdoc */
 import type { ServerHandler } from '../../../server/types';
 import { KnownToken } from '../../../../tokens';
-import { CURRENT_APP, type Application, type Resolve } from '../../../../di';
+import { CURRENT_APP, type Application, type Resolve, Provider } from '../../../../di';
 
-export function HandlerProvider(getApp: () => Application) {
+export function HandlerProvider(getApp: () => Application): Provider<ServerHandler> {
   return (resolve: Resolve): ServerHandler => {
     const parent = resolve(CURRENT_APP);
 

--- a/src/preset/node/handler/providers/index.tsx
+++ b/src/preset/node/handler/providers/index.tsx
@@ -188,13 +188,21 @@ export function provideFetchMiddleware(resolve: Resolve): Middleware[] {
     (request, next) => {
       const innerController = new AbortController();
 
-      request.signal?.addEventListener('abort', () => {
-        innerController.abort();
-      });
+      request.signal?.addEventListener(
+        'abort',
+        () => {
+          innerController.abort();
+        },
+        { once: true },
+      );
 
-      abortController.signal.addEventListener('abort', () => {
-        innerController.abort();
-      });
+      abortController.signal.addEventListener(
+        'abort',
+        () => {
+          innerController.abort();
+        },
+        { once: true },
+      );
 
       return next(new Request(request, { signal: innerController.signal }));
     },
@@ -268,13 +276,21 @@ export function provideAxiosMiddleware(resolve: Resolve): AxiosMiddleware<any>[]
     async (config, next) => {
       const innerController = new AbortController();
 
-      abortController.signal.addEventListener('abort', () => {
-        innerController.abort();
-      });
+      abortController.signal.addEventListener(
+        'abort',
+        () => {
+          innerController.abort();
+        },
+        { once: true },
+      );
 
-      config.signal?.addEventListener?.('abort', () => {
-        innerController.abort();
-      });
+      config.signal?.addEventListener?.(
+        'abort',
+        () => {
+          innerController.abort();
+        },
+        { once: true },
+      );
 
       await next({ ...config, signal: innerController.signal });
     },

--- a/src/preset/server/index.ts
+++ b/src/preset/server/index.ts
@@ -1,0 +1,2 @@
+export type { ServerHandler, ServerMiddleware, ServerHandlerContext } from './types';
+export { getClientIp, getForwardedHeaders, getPageResponseFormat } from './utils';

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -71,6 +71,7 @@ export const KnownToken = {
     serve: createToken<Handler>('serve'),
     Serve: {
       routes: createToken<Array<[string, ServerHandler]>>('serve/routes'),
+      serviceRoutes: createToken<Array<[string, ServerHandler]>>('serve/service-routes'),
       middleware: createToken<ServerMiddleware[]>('serve/middleware'),
     },
 


### PR DESCRIPTION
- `deps`: обновлен `@krutoo/fetch-tools` (patch)
- `tokens`: добавлен токен `Http.Serve.serviceRoutes` (minor)
- `preset/*`: событие `abort` контроллера теперь слушается только один раз (patch)
- добавлен публичный модуль `preset/server` (minor)