### PR TITLE
#69 Сбор кук на сервере работает некорректно

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - react
 - redux
 - redux-saga
+- fetch
 - axios
 - express
 - webpack

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -11,6 +11,7 @@ sidebar_position: 0
 - react
 - redux
 - redux-saga
+- fetch
 - axios
 - express
 - webpack

--- a/src/http/types.ts
+++ b/src/http/types.ts
@@ -1,6 +1,7 @@
-import { LogLevel } from '../log';
+import type { LogLevel } from '../log';
 
 export type { Handler, Enhancer, Middleware, CookieStore } from '@krutoo/fetch-tools';
+
 export type {
   LogData,
   DoneLogData,

--- a/src/preset/bun-handler/index.ts
+++ b/src/preset/bun-handler/index.ts
@@ -11,7 +11,6 @@ import { provideFetchMiddleware } from './providers/fetch-middleware';
 import { provideHandlerMain } from './providers/handler-main';
 import { providePageHelmet } from '../server/providers/page-helmet';
 import { provideSpecificParams } from './providers/specific-params';
-import { provideCookieStore } from './providers/cookie-store';
 import { SpecificExtras } from '../server/utils/specific-extras';
 import { provideElementToString } from '../server/providers/element-to-string';
 import { provideFormatPageResponse } from '../server/providers/format-page-response';
@@ -30,7 +29,6 @@ export function PresetBunHandler(customize?: PresetTuner) {
   // http fetch
   preset.set(KnownToken.Http.fetch, provideFetch);
   preset.set(KnownToken.Http.Fetch.abortController, provideAbortController);
-  preset.set(KnownToken.Http.Fetch.cookieStore, provideCookieStore);
   preset.set(KnownToken.Http.Fetch.middleware, provideFetchMiddleware);
   preset.set(KnownToken.Http.Fetch.Middleware.Log.handler, provideFetchLogHandler);
 

--- a/src/preset/bun-handler/providers/fetch-middleware.ts
+++ b/src/preset/bun-handler/providers/fetch-middleware.ts
@@ -1,7 +1,7 @@
 /* eslint-disable require-jsdoc, jsdoc/require-jsdoc */
 import { Resolve } from '../../../di';
 import { KnownToken } from '../../../tokens';
-import { Middleware, cookie, defaultHeaders } from '../../../http';
+import { Middleware, defaultHeaders } from '../../../http';
 import { getFetchErrorLogging } from '../../isomorphic/utils/get-fetch-error-logging';
 import { getFetchExtraAborting } from '../../isomorphic/utils/get-fetch-extra-aborting';
 import { getFetchLogging } from '../../isomorphic/utils/get-fetch-logging';
@@ -11,7 +11,6 @@ export function provideFetchMiddleware(resolve: Resolve): Middleware[] {
   const config = resolve(KnownToken.Config.base);
   const context = resolve(KnownToken.Http.Handler.context);
   const logHandler = resolve(KnownToken.Http.Fetch.Middleware.Log.handler);
-  const cookieStore = resolve(KnownToken.Http.Fetch.cookieStore);
   const abortController = resolve(KnownToken.Http.Fetch.abortController);
 
   return [
@@ -20,8 +19,6 @@ export function provideFetchMiddleware(resolve: Resolve): Middleware[] {
 
     // обрывание по сигналу из обработчика входящего запроса и по сигналу из конфига исходящего запроса
     getFetchExtraAborting(abortController),
-
-    cookie(cookieStore),
 
     defaultHeaders(getForwardedHeaders(config, context.request)),
 

--- a/src/preset/bun-handler/providers/handler-main.tsx
+++ b/src/preset/bun-handler/providers/handler-main.tsx
@@ -10,24 +10,15 @@ export function provideHandlerMain(resolve: Resolve) {
   const logger = resolve(KnownToken.logger);
   const assetsInit = resolve(KnownToken.Http.Handler.Page.assets);
   const render = resolve(KnownToken.Http.Handler.Page.render);
-  const extras = resolve(KnownToken.Http.Handler.Response.specificExtras);
   const Helmet = resolve(KnownToken.Http.Handler.Page.helmet);
   const abortController = resolve(KnownToken.Http.Fetch.abortController);
   const formatResponse = resolve(KnownToken.Http.Handler.Page.formatResponse);
-
-  // @todo https://github.com/sima-land/isomorph/issues/69
-  // const cookieStore = resolve(KnownToken.Http.Fetch.cookieStore);
-  // const forwardedSetCookie: string[] = [];
-  // const unsubscribeCookieStore = cookieStore.subscribe(setCookieList => {
-  //   forwardedSetCookie.push(...setCookieList);
-  // });
 
   const getAssets = typeof assetsInit === 'function' ? assetsInit : () => assetsInit;
 
   const handler = async (): Promise<Response> => {
     try {
       const assets = await getAssets();
-      const meta = extras.getMeta();
 
       const jsx = (
         <HelmetContext.Provider value={{ title: config.appName, assets }}>
@@ -35,7 +26,7 @@ export function provideHandlerMain(resolve: Resolve) {
         </HelmetContext.Provider>
       );
 
-      const { body, headers } = await formatResponse(jsx, assets, meta);
+      const { body, headers } = await formatResponse(jsx, assets);
 
       return new Response(body, { headers });
     } catch (error) {
@@ -61,16 +52,6 @@ export function provideHandlerMain(resolve: Resolve) {
   };
 
   const enhancer = applyMiddleware(
-    // @todo https://github.com/sima-land/isomorph/issues/69
-    // async (request, next) => {
-    //   const response = await next(request);
-    //   for (const item of forwardedSetCookie) {
-    //     response.headers.append('set-cookie', item);
-    //   }
-    //   unsubscribeCookieStore();
-    //   return response;
-    // },
-
     // ВАЖНО: прерываем исходящие в рамках обработчика http-запросы
     async (request, next) => {
       const response = await next(request);

--- a/src/preset/node-handler/index.ts
+++ b/src/preset/node-handler/index.ts
@@ -14,7 +14,6 @@ import { providePageHelmet } from '../server/providers/page-helmet';
 import { providePageRender } from '../server/providers/page-render';
 import { provideFetchMiddleware } from './providers/fetch-middleware';
 import { provideFetchLogHandler } from '../server/providers/fetch-log-handler';
-import { provideCookieStore } from './providers/cookie-store';
 import { SpecificExtras } from '../server/utils/specific-extras';
 import { provideAcceptType } from './providers/accepts-type';
 import { provideResponseEvents } from './providers/response-events';
@@ -32,7 +31,6 @@ export function PresetHandler(customize?: PresetTuner): Preset {
   // fetch
   preset.set(KnownToken.Http.fetch, provideFetch);
   preset.set(KnownToken.Http.Fetch.middleware, provideFetchMiddleware);
-  preset.set(KnownToken.Http.Fetch.cookieStore, provideCookieStore);
   preset.set(KnownToken.Http.Fetch.abortController, provideAbortController);
   preset.set(KnownToken.Http.Fetch.Middleware.Log.handler, provideFetchLogHandler);
 

--- a/src/preset/node-handler/providers/axios-middleware.ts
+++ b/src/preset/node-handler/providers/axios-middleware.ts
@@ -3,7 +3,7 @@ import { Resolve } from '../../../di';
 import { KnownToken } from '../../../tokens';
 import { HttpStatus } from '../../isomorphic/utils/http-status';
 import { axiosTracingMiddleware } from '../../node/utils/axios-tracing-middleware';
-import { cookieMiddleware, logMiddleware } from '../../../utils/axios';
+import { logMiddleware } from '../../../utils/axios';
 import { getForwardedHeaders } from '../../node/utils/get-forwarded-headers';
 
 /**
@@ -16,7 +16,6 @@ export function provideAxiosMiddleware(resolve: Resolve): Middleware<any>[] {
   const tracer = resolve(KnownToken.Tracing.tracer);
   const context = resolve(KnownToken.ExpressHandler.context);
   const logHandler = resolve(KnownToken.Axios.Middleware.Log.handler);
-  const cookieStore = resolve(KnownToken.Http.Fetch.cookieStore);
   const abortController = resolve(KnownToken.Http.Fetch.abortController);
 
   return [
@@ -59,6 +58,5 @@ export function provideAxiosMiddleware(resolve: Resolve): Middleware<any>[] {
     HttpStatus.axiosMiddleware(),
     axiosTracingMiddleware(tracer, context.res.locals.tracing.rootContext),
     logMiddleware(logHandler),
-    cookieMiddleware(cookieStore),
   ];
 }

--- a/src/preset/node-handler/providers/fetch-middleware.ts
+++ b/src/preset/node-handler/providers/fetch-middleware.ts
@@ -1,5 +1,5 @@
 import { Resolve } from '../../../di';
-import { Middleware, cookie, defaultHeaders } from '../../../http';
+import { Middleware, defaultHeaders } from '../../../http';
 import { KnownToken } from '../../../tokens';
 import { getFetchErrorLogging } from '../../isomorphic/utils/get-fetch-error-logging';
 import { getFetchExtraAborting } from '../../isomorphic/utils/get-fetch-extra-aborting';
@@ -17,7 +17,6 @@ export function provideFetchMiddleware(resolve: Resolve): Middleware[] {
   const tracer = resolve(KnownToken.Tracing.tracer);
   const context = resolve(KnownToken.ExpressHandler.context);
   const logHandler = resolve(KnownToken.Http.Fetch.Middleware.Log.handler);
-  const cookieStore = resolve(KnownToken.Http.Fetch.cookieStore);
   const abortController = resolve(KnownToken.Http.Fetch.abortController);
 
   return [
@@ -29,8 +28,6 @@ export function provideFetchMiddleware(resolve: Resolve): Middleware[] {
 
     // обрывание по сигналу из обработчика входящего запроса и по сигналу из конфига исходящего запроса
     getFetchExtraAborting(abortController),
-
-    cookie(cookieStore),
 
     getFetchTracing(tracer, context.res.locals.tracing.rootContext),
 

--- a/src/preset/node-handler/providers/handler-main.tsx
+++ b/src/preset/node-handler/providers/handler-main.tsx
@@ -15,27 +15,15 @@ export function provideHandlerMain(resolve: Resolve): express.Handler {
   const context = resolve(KnownToken.ExpressHandler.context);
   const render = resolve(KnownToken.Http.Handler.Page.render);
   const assetsInit = resolve(KnownToken.Http.Handler.Page.assets);
-  const extras = resolve(KnownToken.Http.Handler.Response.specificExtras);
   const Helmet = resolve(KnownToken.Http.Handler.Page.helmet);
   const abortController = resolve(KnownToken.Http.Fetch.abortController);
   const formatResponse = resolve(KnownToken.Http.Handler.Page.formatResponse);
 
   const getAssets = typeof assetsInit === 'function' ? assetsInit : () => assetsInit;
 
-  // @todo https://github.com/sima-land/isomorph/issues/69
-  // const cookieStore = resolve(KnownToken.Http.Fetch.cookieStore);
-  // cookieStore.subscribe(setCookieList => {
-  //   for (const setCookie of setCookieList) {
-  //     const parsed = parseSetCookieHeader(setCookie);
-
-  //     parsed && res.cookie(parsed.name, parsed.value, parsed.attrs);
-  //   }
-  // });
-
   return async () => {
     try {
       const assets = await getAssets();
-      const meta = extras.getMeta();
 
       const jsx = (
         <HelmetContext.Provider value={{ title: config.appName, assets }}>
@@ -43,7 +31,7 @@ export function provideHandlerMain(resolve: Resolve): express.Handler {
         </HelmetContext.Provider>
       );
 
-      const { body, headers } = await formatResponse(jsx, assets, meta);
+      const { body, headers } = await formatResponse(jsx, assets);
 
       headers.forEach((hValue, hName) => context.res.setHeader(hName, hValue));
       context.res.send(body);

--- a/src/preset/server/index.ts
+++ b/src/preset/server/index.ts
@@ -1,5 +1,11 @@
-export type { ServerHandler, ServerMiddleware, ServerHandlerContext } from './types';
-export { PAGE_HANDLER_EVENT_TYPE } from './constants';
+export type {
+  ServerHandler,
+  ServerMiddleware,
+  ServerHandlerContext,
+  PageResponseFormatter,
+  PageResponseFormatResult,
+} from './types';
+export { PAGE_HANDLER_EVENT_TYPE, PAGE_FORMAT_PRIORITY } from './constants';
 
 // доступные утилиты
 export { applyServerMiddleware } from './utils/apply-server-middleware';

--- a/src/preset/server/providers/format-page-response.ts
+++ b/src/preset/server/providers/format-page-response.ts
@@ -14,9 +14,12 @@ export function provideFormatPageResponse(resolve: Resolve): PageResponseFormatt
   const config = resolve(KnownToken.Config.base);
   const acceptType = resolve(KnownToken.Http.Handler.Request.acceptType);
   const elementToString = resolve(KnownToken.Http.Handler.Page.elementToString);
+  const extras = resolve(KnownToken.Http.Handler.Response.specificExtras);
 
-  return async (jsx, assets, meta) => {
+  return async (jsx, assets) => {
+    const meta = extras.getMeta();
     const headers = new Headers();
+
     let body: string;
 
     switch (acceptType(PAGE_FORMAT_PRIORITY)) {
@@ -55,6 +58,7 @@ export function provideFormatPageResponse(resolve: Resolve): PageResponseFormatt
 
         // ВАЖНО: DOCTYPE обязательно нужен так как влияет на то как браузер будет парсить html/css
         // ВАЖНО: DOCTYPE нужен только когда отдаем полноценную страницу
+        // @todo переделать  на проверку параметра ?html-doctype=false
         if (config.env === 'development') {
           body = `<!DOCTYPE html>${await elementToString(jsx)}`;
         } else {

--- a/src/preset/server/types.ts
+++ b/src/preset/server/types.ts
@@ -33,7 +33,6 @@ export interface PageResponseFormatter {
   (
     jsx: JSX.Element,
     assets: PageAssets,
-    meta: unknown,
   ): PageResponseFormatResult | Promise<PageResponseFormatResult>;
 }
 

--- a/src/preset/server/utils/__test__/get-forwarded-headers.test.ts
+++ b/src/preset/server/utils/__test__/get-forwarded-headers.test.ts
@@ -35,4 +35,17 @@ describe('getForwardedHeaders', () => {
     expect(result.get('simaland-foo')).toBe('hello');
     expect(result.get('simaland-bar')).toBe('world');
   });
+
+  it('should forward cookie when it is present', () => {
+    const config = { appName: 'app_name', appVersion: 'version', env: 'env' };
+    const request = new Request('http://test.com', {
+      headers: {
+        Cookie: 'foo=123; bar=234',
+      },
+    });
+    const result = getForwardedHeaders(config, request);
+
+    expect(result.get('user-agent')).toBe('simaland-app_name/version');
+    expect(result.get('cookie')).toBe('foo=123; bar=234');
+  });
 });

--- a/src/preset/server/utils/get-forwarded-headers.ts
+++ b/src/preset/server/utils/get-forwarded-headers.ts
@@ -15,9 +15,14 @@ export function getForwardedHeaders(config: BaseConfig, request: Request): Heade
 
   // client ip
   const clientIp = getClientIp(request);
-
   if (clientIp) {
     result.set('X-Client-Ip', clientIp);
+  }
+
+  // cookie
+  const cookie = request.headers.get('cookie');
+  if (cookie) {
+    result.set('cookie', cookie);
   }
 
   // service headers


### PR DESCRIPTION
- preset/server: PageResponseFormatter теперь не получает meta (major)
- preset/node-handler: удален промежуточный слой cookie для fetch (major)
- preset/bun-handler: удален промежуточный слой cookie для fetch (major)
- preset/server: getForwardedHeaders теперь прокидывает куки по аналогии с preset/node (minor)

Closes #69 